### PR TITLE
Changed all JA references to JF

### DIFF
--- a/jf_analysis.py
+++ b/jf_analysis.py
@@ -1,5 +1,5 @@
 """
-JA analysis
+JF analysis
 ============
 Analyses a detector for Jitter and F1 score.
 At the heart is the jitter detection algorithm on annotation/detection
@@ -7,7 +7,7 @@ pairs. A Jitter of 0ms gives a 100% score and then drops to
 zero with increased jitter.
 Missed beats and extra/spurios detections are then used to calculate F1
 as a normalised measure independent on the number of beats.
-The overall score is then: JA = Jitter/% * F1/%.
+The overall score is then: jf = Jitter/% * F1/%.
 """
 import numpy as np
 import util
@@ -20,10 +20,10 @@ norm_jitter = 10E-3 # sec
 a = 10 # number of annotated beats to trim from start
 b = -5 # number of annotated beats to trim from end
 
-# keys for the ja dict:
+# keys for the jf dict:
 key_jitter = "jitter" # temproal jitter in s
 key_f1 = "f1" # F1 score
-key_ja = "ja" # ja score
+key_jf = "jf" # jf score
 key_tp = "TP" # True positives
 key_fp = "FP" # False positives
 key_fn = "FN" # False negatives
@@ -61,7 +61,7 @@ def nearest_diff(annotation, nearest_match):
 
 def score(jitter,f1):
     """
-    Calculates the JA score by multiplying the normalised jitter
+    Calculates the JF score by multiplying the normalised jitter
     with f1 which in turn is based on missing and extra beats.
     """
     jitter_score = 1 / ( 1 + (jitter / norm_jitter) ) # normalised jitter 0..1
@@ -70,18 +70,18 @@ def score(jitter,f1):
 
 def evaluate(det_posn, anno_R, fs, nSamples, trim=True):
     """
-    JA analysis of interval variation, missed beat and extra detection positions
+    JF analysis of interval variation, missed beat and extra detection positions
     det_posn: the timestamps of the detector in sample positions
     anno_R: the ground truth in samples
     fs: sampling rate of the ECG file
     nSamples: number of samples in the ECG file
     returns:
-    ja[key_jitter]   : jitter in s
-    ja[key_tp]       : true positive beats
-    ja[key_fp]       : false positive beats
-    ja[key_fn]       : false negative beats
-    ja[key_f1]       : f1
-    ja[key_ja]       : JA Score
+    jf[key_jitter]   : jitter in s
+    jf[key_tp]       : true positive beats
+    jf[key_fp]       : false positive beats
+    jf[key_fn]       : false negative beats
+    jf[key_f1]       : f1
+    jf[key_jf]       : JF Score
     """
 
     # Median delay of the detection against the annotations
@@ -115,21 +115,21 @@ def evaluate(det_posn, anno_R, fs, nSamples, trim=True):
         difference = np.abs(d / fs)
         differences_for_jitter.append(difference)
 
-    ja = {}
+    jf = {}
 
-    ja[key_jitter] = stats.median_abs_deviation(differences_for_jitter)
+    jf[key_jitter] = stats.median_abs_deviation(differences_for_jitter)
     fp = len_det_posn - len(differences_for_jitter) # all detections - true positive = false positive
     fn = len_anno_R - len(differences_for_jitter) # all detections
     tp = len(differences_for_jitter)
-    ja[key_tp] = tp
-    ja[key_fp] = fp
-    ja[key_fn] = fn
+    jf[key_tp] = tp
+    jf[key_fp] = fp
+    jf[key_fn] = fn
     if (tp + fp + fn) > 0:
         f1 = (2*tp)/(2*tp + fp + fn)
-        ja[key_f1] = f1
-        ja[key_ja] = score(ja[key_jitter],f1)
+        jf[key_f1] = f1
+        jf[key_jf] = score(jf[key_jitter],f1)
     else:
-        ja[key_f1] = False
-        ja[key_ja] = False
-    print(ja)
-    return ja
+        jf[key_f1] = False
+        jf[key_jf] = False
+    print(jf)
+    return jf

--- a/jf_evaluate_all_detectors.py
+++ b/jf_evaluate_all_detectors.py
@@ -14,7 +14,7 @@ from ecgdetectors import Detectors
 import pathlib # For local file use
 from multiprocessing import Process
 
-# The JA analysis for a detector
+# The JF analysis for a detector
 import jf_analysis
 
 # directory where the results are stored

--- a/jf_stats_activities.py
+++ b/jf_stats_activities.py
@@ -20,14 +20,14 @@ alpha = 0.05
 
 minjf = 90 # %
 
-def get_ja(detector_name, leads, experiment):
+def get_jf(detector_name, leads, experiment):
     f = open(resultsdir+"/jf_"+detector_name+".json","r")
     js = f.read()
     data = json.loads(js)
     s = []
     for i in data[leads][experiment]:
-        if i["ja"]:
-            s.append(i["ja"]*100)
+        if i["jf"]:
+            s.append(i["jf"]*100)
     return np.array(s)
 
 
@@ -36,8 +36,8 @@ def get_result(det, leads):
     m = []
     s = []
     for e in experiment_names:
-        m.append(np.mean(get_ja(det, leads, e)))
-        s.append(np.std(get_ja(det, leads, e)))
+        m.append(np.mean(get_jf(det, leads, e)))
+        s.append(np.std(get_jf(det, leads, e)))
 
     return m,s
 
@@ -59,7 +59,7 @@ def calc_stats(det,leads):
         print(e," & ",end='')
     print("\\\\")
     for e in experiment_names:
-        r1 = get_ja(det, leads, e)
+        r1 = get_jf(det, leads, e)
         t,p = stats.ttest_1samp(r1,minjf,alternative='greater')
         print_stat(p)
     print()

--- a/jf_stats_detectors.py
+++ b/jf_stats_detectors.py
@@ -20,14 +20,14 @@ alpha = 0.05
 
 minja = 90 # %
 
-def get_ja(detector_name, leads, experiment):
+def get_jf(detector_name, leads, experiment):
     f = open(resultsdir+"/jf_"+detector_name+".json","r")
     js = f.read()
     data = json.loads(js)
     s = []
     for i in data[leads][experiment]:
-        if i["ja"]:
-            s.append(i["ja"]*100)
+        if i["jf"]:
+            s.append(i["jf"]*100)
     return np.array(s)
 
 
@@ -36,9 +36,9 @@ def get_result(det, leads, experiment):
     m = []
     s = []
     for det in det_names:
-        print(det,experiment,get_ja(det, leads, experiment))
-        m.append(np.mean(get_ja(det, leads, experiment)))
-        s.append(np.std(get_ja(det, leads, experiment)))
+        print(det,experiment,get_jf(det, leads, experiment))
+        m.append(np.mean(get_jf(det, leads, experiment)))
+        s.append(np.std(get_jf(det, leads, experiment)))
 
     return np.array(m),np.array(s)
 
@@ -60,7 +60,7 @@ def calc_stats(leads, experiment):
         print(det1," & ",end='')
     print("\\\\")
     for det1 in det_names:
-        r1 = get_ja(det1, leads, experiment)
+        r1 = get_jf(det1, leads, experiment)
         t,p = stats.ttest_1samp(r1,minja,alternative='greater')
         print_stat(p)
     print()

--- a/jf_stats_detectors_sitting.py
+++ b/jf_stats_detectors_sitting.py
@@ -19,14 +19,14 @@ alpha = 0.05
 
 minja = 90 # %
 
-def get_ja(detector_name):
+def get_jf(detector_name):
     f = open(resultsdir+"/jf_"+detector_name+".json","r")
     js = f.read()
     data = json.loads(js)
     s = []
     for i in data[leads][experiment]:
-        if i["ja"]:
-            s.append(i["ja"]*100)
+        if i["jf"]:
+            s.append(i["jf"]*100)
     return np.array(s)
 
 
@@ -41,8 +41,8 @@ def get_result(det):
             n = n + len(data_anno)
     for det in det_names:
         print(det,experiment)
-        m.append(np.mean(get_ja(det)))
-        s.append(np.std(get_ja(det)))
+        m.append(np.mean(get_jf(det)))
+        s.append(np.std(get_jf(det)))
 
     return n,np.array(m),np.array(s)
 


### PR DESCRIPTION
I noticed the the name of the analysis changed from JA to JF in the preprint (https://www.biorxiv.org/content/10.1101/722397v6). While the documentation now refers to the JF score, in the code the variable names along with dictionary keys were still called "ja". I changed the code variable names and dictionary keys from ja to jf to avoid confusion.